### PR TITLE
Fix for file globbing on windows.

### DIFF
--- a/scripts/v3/add_column.pl
+++ b/scripts/v3/add_column.pl
@@ -290,7 +290,7 @@ mkpath($temp_dir);
 # get files to be processed from cmd line args
 #
 
-my @files = @ARGV;
+my @files = map { glob } @ARGV;
 
 for my $file_in (@files) {
 	


### PR DESCRIPTION
Globbing doesn't work on the Windows prompt, so you can't even make it through your sample in the documentation. This fixes that (small) problem in `add_column.pl`.
