### PR TITLE
Fix out-of-order lines

### DIFF
--- a/texts/la/silius_italicus.punica/silius_italicus.punica.part.11.tess
+++ b/texts/la/silius_italicus.punica/silius_italicus.punica.part.11.tess
@@ -288,12 +288,6 @@
 <sil. 11.288> Personat Euboica Teuthras testudine, Cymes
 <sil. 11.289> incola, et obtusas immiti murmure saeuae
 <sil. 11.290> inter bella tubae permulcet cantibus auris.
-<sil. 11.453> namque chaos, caecam quondam sine sidere molem
-<sil. 11.454> non surgente die, ac mundum sine luce canebat.
-<sil. 11.455> tum deus ut liquidi disclusset stagna profundi
-<sil. 11.456> tellurisque globum media compage locasset;
-<sil. 11.457> ut celsum superis habitare dedisset Olympum,
-<sil. 11.458> castaque Saturni monstrabat saecula patris.
 <sil. 11.291> iamque Iouem et laetos per furta canebat amores
 <sil. 11.292> Electraeque toros Atlantidos, unde creatus
 <sil. 11.293> proles digna deum tum Dardanus, isque Tonanti
@@ -456,6 +450,12 @@
 <sil. 11.450> heroum mentes et magni pectora Achillis,
 <sil. 11.451> Centauro dilecta chelys, compesceret iras
 <sil. 11.452> percussa fide uel pelagi uel tristis Auerni.
+<sil. 11.453> namque chaos, caecam quondam sine sidere molem
+<sil. 11.454> non surgente die, ac mundum sine luce canebat.
+<sil. 11.455> tum deus ut liquidi disclusset stagna profundi
+<sil. 11.456> tellurisque globum media compage locasset;
+<sil. 11.457> ut celsum superis habitare dedisset Olympum,
+<sil. 11.458> castaque Saturni monstrabat saecula patris.
 <sil. 11.459> sed quos pulsabat Riphaeum ad Strymona, nerui,
 <sil. 11.460> auditus superis, auditus manibus Orpheus,
 <sil. 11.461> emerito fulgent clara inter sidera caelo.


### PR DESCRIPTION
The following lines were out of order, appearing after l. 290:
```
<sil. 11.453> namque chaos, caecam quondam sine sidere molem
<sil. 11.454> non surgente die, ac mundum sine luce canebat.
<sil. 11.455> tum deus ut liquidi disclusset stagna profundi
<sil. 11.456> tellurisque globum media compage locasset;
<sil. 11.457> ut celsum superis habitare dedisset Olympum,
<sil. 11.458> castaque Saturni monstrabat saecula patris.
```

This change was a suggestion of Summers, but is rejected by Delz (the modern edition). I have no strong opinion on the textual issue, but I think that if the lines are accepted as a reordering then they should be renumbered, because it can cause errors in automatic processing of results.